### PR TITLE
Allow for closing dots in YAML front matter.

### DIFF
--- a/MacDown/Code/Extension/NSString+Lookup.m
+++ b/MacDown/Code/Extension/NSString+Lookup.m
@@ -56,7 +56,7 @@
 {
     NSRegularExpressionOptions op = NSRegularExpressionDotMatchesLineSeparators;
     NSRegularExpression *regex =
-        [NSRegularExpression regularExpressionWithPattern:@"^---\n(.*?\n)---"
+        [NSRegularExpression regularExpressionWithPattern:@"^---\n(.*?\n)((---)|(\.\.\.))"
                                                   options:op error:NULL];
     NSTextCheckingResult *result =
         [regex firstMatchInString:self options:0


### PR DESCRIPTION
Adding to the regexp to allow for three dots `...` as well as the current three hyphens `---` to close the YAML front matter.